### PR TITLE
Add .gitattributes to make package lighter when deploying for production.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/examples export-ignore


### PR DESCRIPTION
Running `composer install --prefer-dist` will exclude any files and directories specified within .gitattributes.
