### PR TITLE
Make sure defaults are not the only columns.

### DIFF
--- a/src/CPT.php
+++ b/src/CPT.php
@@ -564,7 +564,7 @@ class CPT {
 		if ( ! isset( $this->columns ) ) {
 
 			// Default columns
-			$columns = array(
+			$defaults = array(
 				'cb' => '<input type="checkbox" />',
 				'title' => __( 'Title', $this->textdomain )
 			);
@@ -591,6 +591,8 @@ class CPT {
 
 			// Add date of post to end of columns.
 			$columns['date'] = __( 'Date', $this->textdomain );
+
+			$columns = array_replace_recursive( $defaults, $columns );
 
 		} else {
 


### PR DESCRIPTION
Since default columns are now set, if no custom columns are
registered/used only the default columns show (including custom columns
by 3rd party plugins).